### PR TITLE
Ensure dhall files can be generated with imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # urai
 
 [![GitHub CI](https://github.com/navilan/urai/workflows/CI/badge.svg)](https://github.com/navilan/urai/actions)
-[![Build status](https://img.shields.io/travis/navilan/urai.svg?logo=travis)](https://travis-ci.org/navilan/urai)
-[![Windows build status](https://ci.appveyor.com/api/projects/status/github/navilan/urai?branch=master&svg=true)](https://ci.appveyor.com/project/navilan/urai)
+[![Windows build status](https://ci.appveyor.com/api/projects/status/github/navilan/urai?branch=main&svg=true)](https://ci.appveyor.com/project/navilan/urai)
 [![Hackage](https://img.shields.io/hackage/v/urai.svg?logo=haskell)](https://hackage.haskell.org/package/urai)
 [![MPL-2.0 license](https://img.shields.io/badge/license-MPL--2.0-blue.svg)](LICENSE)
 

--- a/src/Urai/Config/ConfigWriter.hs
+++ b/src/Urai/Config/ConfigWriter.hs
@@ -1,16 +1,17 @@
 -- | Writes the configuration types as Dhall files
 
 module Urai.Config.ConfigWriter
-    ( printDhall
-    )
+  ( printDhall
+  )
 where
 
-import qualified Data.Text.IO as TIO
-import Development.Shake.FilePath ((</>))
+import qualified Data.Text.IO                  as TIO
+import           Development.Shake.FilePath     ( (</>) )
 
 import qualified Urai.Config.Meta              as M
 import qualified Urai.Config.OpenGraph         as O
 import qualified Urai.Config.TwitterCard       as T
+import qualified Urai.Config.Social            as S
 import           Urai.Config.Module
 
 
@@ -20,8 +21,9 @@ printModule d f m = do
   TIO.writeFile (d </> f) txt
 
 
-printDhall ::  FilePath -> IO ()
+printDhall :: FilePath -> IO ()
 printDhall p = do
-  printModule p "Meta.dhall" M.printDhall
-  printModule p "OpenGraph.dhall" O.printDhall
+  printModule p "Meta.dhall"        M.printDhall
+  printModule p "OpenGraph.dhall"   O.printDhall
   printModule p "TwitterCard.dhall" T.printDhall
+  printModule p "Social.dhall"      S.printDhall

--- a/src/Urai/Config/Features.hs
+++ b/src/Urai/Config/Features.hs
@@ -1,0 +1,14 @@
+-- | Set of configuration options supported for the site
+
+module Urai.Config.Features
+  ( Social
+  , SocialFeatures
+  )
+where
+
+data Social = Twitter
+            | OpenGraph
+            deriving stock (Show, Eq, Ord)
+
+
+newtype SocialFeatures = SocialFeatures [Social] deriving newtype (Show, Eq, Ord)

--- a/src/Urai/Config/OpenGraph.hs
+++ b/src/Urai/Config/OpenGraph.hs
@@ -22,6 +22,7 @@ module Urai.Config.OpenGraph
     , OpenGraphWebsite(..)
     , OpenGraphProfileItem(..)
     , OpenGraph(..)
+    , declareModule
     , printDhall
     )
 where

--- a/src/Urai/Config/Social.hs
+++ b/src/Urai/Config/Social.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE StrictData                 #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeOperators              #-}
+-- | Social features for a urai site.
+
+module Urai.Config.Social
+    ( declareModule
+    , printDhall
+    )
+where
+
+import           System.FilePath                ( splitDirectories )
+
+import           Dhall                          ( Encoder(..)
+                                                , FromDhall(..)
+                                                , ToDhall(..)
+                                                , inject
+                                                )
+
+import           Dhall.Deriving                 ( type (<<<)
+                                                , CamelCase
+                                                , Codec(..)
+                                                , DropPrefix
+                                                , Field
+                                                )
+
+import           Urai.Config.Module
+import qualified Urai.Config.TwitterCard       as TW
+import qualified Urai.Config.OpenGraph         as OG
+import           Dhall.Core                     ( Directory(..)
+                                                , File(..)
+                                                , Import(..)
+                                                , ImportHashed(..)
+                                                , ImportMode(..)
+                                                , ImportType(..)
+                                                , FilePrefix(..)
+                                                )
+import qualified Data.Text                     as T
+
+
+data Social = Social
+    { socialTwitter   :: TW.TwitterCard
+    , socialOpenGraph :: OG.OpenGraph
+    }
+    deriving stock Generic
+    deriving (FromDhall, ToDhall) via Codec
+        (Field (CamelCase <<< DropPrefix "social"))
+        Social
+
+
+fromPath :: Text -> File
+fromPath p = File
+    { directory = Directory . fmap T.pack $ fromMaybe
+                      ([])
+                      (viaNonEmpty tail comps)
+    , file      = T.pack $ fromMaybe "" (viaNonEmpty head comps)
+    }
+  where
+    comps =
+        reverse . filter (\part -> part /= "/") . splitDirectories $ toString p
+
+makeImport :: FilePrefix -> Text -> Import
+makeImport fp p = Import
+    { importHashed = ImportHashed { hash       = Nothing
+                                  , importType = Local fp (fromPath p)
+                                  }
+    , importMode   = Code
+    }
+
+
+declareModule :: Module ()
+declareModule = do
+    addImport (makeImport Here "TwitterCard.dhall") "T" TW.declareModule
+    addImport (makeImport Here "OpenGraph.dhall")   "O" OG.declareModule
+    addBinding "Social" (declared (inject @Social))
+
+
+printDhall :: Module Text
+printDhall = do
+    declareModule
+    evalModule

--- a/src/Urai/Config/Social.hs
+++ b/src/Urai/Config/Social.hs
@@ -53,13 +53,13 @@ data Social = Social
 fromPath :: Text -> File
 fromPath p = File
     { directory = Directory . fmap T.pack $ fromMaybe
-                      ([])
+                      []
                       (viaNonEmpty tail comps)
     , file      = T.pack $ fromMaybe "" (viaNonEmpty head comps)
     }
   where
     comps =
-        reverse . filter (\part -> part /= "/") . splitDirectories $ toString p
+        reverse . filter (/= "/") . splitDirectories $ toString p
 
 makeImport :: FilePrefix -> Text -> Import
 makeImport fp p = Import

--- a/src/Urai/Config/TwitterCard.hs
+++ b/src/Urai/Config/TwitterCard.hs
@@ -12,6 +12,7 @@ module Urai.Config.TwitterCard
     , TwitterAppCard(..)
     , TwitterPlayerCard(..)
     , TwitterCard(..)
+    , declareModule
     , printDhall
     )
 where
@@ -139,7 +140,7 @@ instance ToDhall TwitterCard where
     injectWith _ = injectTwitterCard
 
 
-declareModule :: Module()
+declareModule :: Module ()
 declareModule = do
     addBinding "TwitterInfo"        (declared (inject @TwitterInfo))
     addBinding "TwitterSummaryCard" (declared (inject @TwitterSummaryCard))

--- a/urai.cabal
+++ b/urai.cabal
@@ -83,6 +83,7 @@ library
                        text-manipulate    ^>= 0.2.0.1,
                        containers         ^>= 0.6.2.1,
                        ordered-containers ^>= 0.2.2,
+                       base16-bytestring   == 0.1.1.7,
 
 executable urai
   import:              common-options

--- a/urai.cabal
+++ b/urai.cabal
@@ -69,13 +69,16 @@ library
                        Urai.Config.Module
                        Urai.Config.TwitterCard
                        Urai.Config.OpenGraph
+                       Urai.Config.Features
+                       Urai.Config.Social
   build-depends:       text               ^>= 1.2.3.0,
                        shake              ^>= 0.19.1,
-                       dhall              ^>= 1.34.0,
+                       dhall              ^>= 1.35.0,
                        either             ^>= 5.0.1.1,
                        extra              ^>= 1.7.4,
                        pandoc             ^>= 2.10.1,
                        prettyprinter      ^>= 1.7.0,
+                       filepath           ^>= 1.4.2.1,
                        filepattern        ^>= 0.1.2,
                        text-manipulate    ^>= 0.2.0.1,
                        containers         ^>= 0.6.2.1,


### PR DESCRIPTION
Most of the code for Urai and extensions shall be written in Haskell.
Most of the code for Urai generated sites, however, I'd like them to be
written in Dhall. This requires the following:

* Good ergonomics
* Batteries-included library to make Urai related functions and types
  readily available
* Ability to add plugins to change the Dhall context
* Granular type system for user defined data and functions

In order to accomplish these goals, the strategy I have chosen is to
generate Dhall files through Haskell types. This commit allows
generation of Dhall types that include other Dhall types (also
generated).

This is still not robust enough to handle all situations. Nested imports
for example. However, this seems to solve the main use cases for Urai.

Next Steps:

- [ ] Generate defaults
- [ ] Feature set based generation